### PR TITLE
Remove unnecessary exception stack trace logging

### DIFF
--- a/AgentClient.java
+++ b/AgentClient.java
@@ -92,7 +92,6 @@ public class AgentClient {
 
         } catch (UnknownHostException e) {
             System.err.println("Don't know about host " + SERVER_HOSTNAME);
-            e.printStackTrace();
         } catch (IOException e) {
             if (running) {
                 System.err.println("Agent I/O error or connection lost: " + e.getMessage());


### PR DESCRIPTION
Eliminate the stack trace logging for `UnknownHostException` to reduce clutter in the output.